### PR TITLE
OktaLogger: Update Firebase dependency v.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
 executors:
   apple-ci-arm-medium:
     macos:
-      xcode: 14.3.1
+      xcode: 15.2.0
     resource_class: macos.m1.medium.gen1
     
 commands:
@@ -35,10 +35,10 @@ commands:
     steps:
       - run:
          name: OktaSQLiteStorage unit tests"
-         command: set -o pipefail && xcodebuild -workspace "OktaLogger.xcworkspace" -scheme "OktaSQLiteStorageTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 14 Pro Max" test
+         command: set -o pipefail && xcodebuild -workspace "OktaLogger.xcworkspace" -scheme "OktaSQLiteStorageTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15 Pro Max" test
       - run:
          name: OktaLogger unit tests"
-         command: set -o pipefail && xcodebuild -workspace "OktaLogger.xcworkspace" -scheme "OktaLoggerTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 14 Pro Max" test
+         command: set -o pipefail && xcodebuild -workspace "OktaLogger.xcworkspace" -scheme "OktaLoggerTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15 Pro Max" test
 #      - run:
 #         name: OktaAnalytics unit tests"
 #         command: set -o pipefail && xcodebuild -workspace "OktaLogger.xcworkspace" -scheme "OktaAnalyticsTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 14" test

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'APACHE2', :file => 'LICENSE' }
   s.author           = { "Okta Developers" => "developer@okta.com" }
   s.source           = { :git => "https://github.com/okta/okta-logger-swift.git",  :tag => "OktaLogger-"+s.version.to_s }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
   s.watchos.deployment_target = '6.0'
   s.swift_version = '5.0'
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     crashlytics.source_files = [
       'Sources/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift'
     ]
-    crashlytics.dependency 'Firebase/Crashlytics', '~> 10'
+    crashlytics.dependency 'Firebase/Crashlytics', '~> 11'
     crashlytics.dependency 'OktaLogger/Core'
   end
 

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OktaLogger"
-  s.version          = "1.3.19"
+  s.version          = "1.3.20"
   s.summary          = "Logging proxy for standardized logging interface across products"
   s.description      = "Standard interface for all logging in Okta apps + SDK. Supports file, console, firebase logging destinations."
   s.homepage         = "https://github.com/okta/okta-logger-swift"
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     crashlytics.source_files = [
       'Sources/OktaLogger/FirebaseCrashlyticsLogger/OktaLoggerFirebaseCrashlyticsLogger.swift'
     ]
-    crashlytics.dependency 'Firebase/Crashlytics', '~> 9'
+    crashlytics.dependency 'Firebase/Crashlytics', '~> 10'
     crashlytics.dependency 'OktaLogger/Core'
   end
 

--- a/OktaLogger.podspec
+++ b/OktaLogger.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.author           = { "Okta Developers" => "developer@okta.com" }
   s.source           = { :git => "https://github.com/okta/okta-logger-swift.git",  :tag => "OktaLogger-"+s.version.to_s }
   s.ios.deployment_target = '12.0'
-  s.osx.deployment_target = '10.14'
-  s.watchos.deployment_target = '6.0'
+  s.osx.deployment_target = '10.15'
+  s.watchos.deployment_target = '7.0'
   s.swift_version = '5.0'
   s.default_subspec = "Complete"
 

--- a/OktaLogger.xcodeproj/project.pbxproj
+++ b/OktaLogger.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 				D5C824D22469DBF1005CF747 /* Resources */,
 				80DDE78E24B962C900D0E2F3 /* Embed Frameworks */,
 				7B0C4EE7276D1DAC0033BDC6 /* SwiftLint */,
+				74D61838C0B5CF075047C1B4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -607,6 +608,7 @@
 				D5C824DA2469DBF1005CF747 /* Frameworks */,
 				D5C824DB2469DBF1005CF747 /* Resources */,
 				8A04A3992610D1FAF3446F06 /* [CP] Embed Pods Frameworks */,
+				3DC8220AD478472683310979 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -628,6 +630,7 @@
 				E251E7F9248AD1B400EF466D /* Resources */,
 				DEC5276724DBFE6C0022B698 /* ShellScript */,
 				B6A235592A5E2CBBF90E51EE /* [CP] Embed Pods Frameworks */,
+				0B381B23C8AFF19DC939F232 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -648,6 +651,7 @@
 				F3575F282A0AD1840008A965 /* Sources */,
 				F3575F292A0AD1840008A965 /* Frameworks */,
 				F3575F2A2A0AD1840008A965 /* Resources */,
+				B0C0072AF7A19504676FD526 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -666,6 +670,7 @@
 				F3D5EA122A283E5E00530838 /* Sources */,
 				F3D5EA132A283E5E00530838 /* Frameworks */,
 				F3D5EA142A283E5E00530838 /* Resources */,
+				E838532ECED9A96DCCFBAEFD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -794,6 +799,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0B381B23C8AFF19DC939F232 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerDemoApp/Pods-OktaLoggerDemoApp-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		0F2298F77B72900393068192 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -860,6 +882,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		3DC8220AD478472683310979 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		58278EF008B42FA45AF4BBBA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -880,6 +919,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		74D61838C0B5CF075047C1B4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLogger/Pods-OktaLogger-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaLogger/Pods-OktaLogger-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLogger/Pods-OktaLogger-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7906DFF612F22A1930DEE58D /* [CP] Check Pods Manifest.lock */ = {
@@ -939,6 +995,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaLoggerTests/Pods-OktaLoggerTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		B0C0072AF7A19504676FD526 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaAnalytics/Pods-OktaAnalytics-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaAnalytics/Pods-OktaAnalytics-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaAnalytics/Pods-OktaAnalytics-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		B6A235592A5E2CBBF90E51EE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -995,6 +1068,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+		};
+		E838532ECED9A96DCCFBAEFD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaAnalyticsTests/Pods-OktaAnalyticsTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OktaAnalyticsTests/Pods-OktaAnalyticsTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OktaAnalyticsTests/Pods-OktaAnalyticsTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		F26A1DAF665C501039D40073 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_modular_headers!
 
 target 'OktaLogger' do
     pod 'Firebase/AnalyticsWithoutAdIdSupport'
-    pod 'Firebase/Crashlytics', '~>10.0.0'
+    pod 'Firebase/Crashlytics', '~>11.3.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
     pod 'Instabug', '13.3.0'
     pod 'SwiftLint', '0.51'
@@ -26,7 +26,7 @@ end
 target 'OktaLoggerDemoApp' do
     pod 'OktaLogger', :path => '.'
     pod 'OktaAnalytics', :path => '.'
-    pod 'Firebase/Crashlytics', '~>10.0.0'
+    pod 'Firebase/Crashlytics', '~>11.3.0'
 
     target 'OktaLoggerTests' do
       inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,8 @@ platform :ios, '13.0'
 use_modular_headers!
 
 target 'OktaLogger' do
-    pod 'Firebase/Crashlytics', '~>9.4.0'
+    pod 'Firebase/AnalyticsWithoutAdIdSupport'
+    pod 'Firebase/Crashlytics', '~>10.0.0'
     pod 'CocoaLumberjack/Swift', '~>3.6.0'
     pod 'Instabug', '13.3.0'
     pod 'SwiftLint', '0.51'
@@ -25,7 +26,7 @@ end
 target 'OktaLoggerDemoApp' do
     pod 'OktaLogger', :path => '.'
     pod 'OktaAnalytics', :path => '.'
-    pod 'Firebase/Crashlytics', '~>9.4.0'
+    pod 'Firebase/Crashlytics', '~>10.0.0'
 
     target 'OktaLoggerTests' do
       inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,52 +10,46 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - Firebase/AnalyticsWithoutAdIdSupport (9.4.0):
+  - Firebase/AnalyticsWithoutAdIdSupport (10.0.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics/WithoutAdIdSupport (~> 9.4.0)
-  - Firebase/CoreOnly (9.4.0):
-    - FirebaseCore (= 9.4.0)
-  - Firebase/Crashlytics (9.4.0):
+    - FirebaseAnalytics/WithoutAdIdSupport (~> 10.0.0)
+  - Firebase/CoreOnly (10.0.0):
+    - FirebaseCore (= 10.0.0)
+  - Firebase/Crashlytics (10.0.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 9.4.0)
-  - FirebaseAnalytics/WithoutAdIdSupport (9.4.0):
-    - FirebaseCore (~> 9.0)
-    - FirebaseInstallations (~> 9.0)
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.4.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
-    - GoogleUtilities/MethodSwizzler (~> 7.7)
-    - GoogleUtilities/Network (~> 7.7)
-    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - FirebaseCrashlytics (~> 10.0.0)
+  - FirebaseAnalytics/WithoutAdIdSupport (10.0.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.0.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/MethodSwizzler (~> 7.8)
+    - GoogleUtilities/Network (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (9.4.0):
-    - FirebaseCoreDiagnostics (~> 9.0)
-    - FirebaseCoreInternal (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.6.0):
-    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreInternal (9.6.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseCrashlytics (9.4.0):
-    - FirebaseCore (~> 9.0)
-    - FirebaseInstallations (~> 9.0)
-    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
-    - GoogleUtilities/Environment (~> 7.7)
+  - FirebaseCore (10.0.0):
+    - FirebaseCoreInternal (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Logger (~> 7.8)
+  - FirebaseCoreInternal (10.29.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseCrashlytics (10.0.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (9.6.0):
-    - FirebaseCore (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/UserDefaults (~> 7.7)
+  - FirebaseInstallations (10.29.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - GoogleAppMeasurement/WithoutAdIdSupport (9.4.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
-    - GoogleUtilities/MethodSwizzler (~> 7.7)
-    - GoogleUtilities/Network (~> 7.7)
-    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.0.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/MethodSwizzler (~> 7.8)
+    - GoogleUtilities/Network (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
@@ -97,25 +91,25 @@ PODS:
     - nanopb/encode (= 2.30909.1)
   - nanopb/decode (2.30909.1)
   - nanopb/encode (2.30909.1)
-  - OktaAnalytics (2.0.4):
+  - OktaAnalytics (2.1):
     - AppCenter (~> 5)
     - Firebase/AnalyticsWithoutAdIdSupport
     - OktaLogger/Core (~> 1)
     - OktaSQLiteStorage (~> 0.0.4)
-  - OktaLogger (1.3.19):
-    - OktaLogger/Complete (= 1.3.19)
-  - OktaLogger/Complete (1.3.19):
+  - OktaLogger (1.3.20):
+    - OktaLogger/Complete (= 1.3.20)
+  - OktaLogger/Complete (1.3.20):
     - OktaLogger/FileLogger
     - OktaLogger/FirebaseCrashlytics
     - OktaLogger/InstabugLogger
-  - OktaLogger/Core (1.3.19)
-  - OktaLogger/FileLogger (1.3.19):
+  - OktaLogger/Core (1.3.20)
+  - OktaLogger/FileLogger (1.3.20):
     - CocoaLumberjack/Swift (~> 3)
     - OktaLogger/Core
-  - OktaLogger/FirebaseCrashlytics (1.3.19):
-    - Firebase/Crashlytics (~> 9)
+  - OktaLogger/FirebaseCrashlytics (1.3.20):
+    - Firebase/Crashlytics (~> 10)
     - OktaLogger/Core
-  - OktaLogger/InstabugLogger (1.3.19):
+  - OktaLogger/InstabugLogger (1.3.20):
     - Instabug (~> 13)
     - OktaLogger/Core
   - OktaSQLiteStorage (0.0.5):
@@ -133,7 +127,7 @@ DEPENDENCIES:
   - AppCenter (~> 5.0.0)
   - CocoaLumberjack/Swift (~> 3.6.0)
   - Firebase/AnalyticsWithoutAdIdSupport
-  - Firebase/Crashlytics (~> 9.4.0)
+  - Firebase/Crashlytics (~> 10.0.0)
   - GRDB.swift/SQLCipher (= 6.20.2)
   - Instabug (= 13.3.0)
   - OktaAnalytics (from `.`)
@@ -150,7 +144,6 @@ SPEC REPOS:
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
-    - FirebaseCoreDiagnostics
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
@@ -175,26 +168,25 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppCenter: 994875ea7941b9e168babb98299f900a94bcef13
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  Firebase: 7703fc4022824b6d6db1bf7bea58d13b8e17ec46
-  FirebaseAnalytics: a1a24e72b7ba7f47045a4633f1abb545c07bd29c
-  FirebaseCore: 9a2b10270a854731c4d4d8a97d0aa8380ec3458d
-  FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
-  FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
-  FirebaseCrashlytics: 121ea1d37f4906c94c4c9307297af5121b98b789
-  FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
-  GoogleAppMeasurement: 5d69e04287fc2c10cc43724bfa4bf31fc12c3dff
+  Firebase: 1b810f3d0c0532e27a48f1961f8c0400a668a2cf
+  FirebaseAnalytics: 9921a52739f4ab66099da31b6e0243db78a3ac0a
+  FirebaseCore: 97f48a3a567a72b8d4daa0f03c3aadb78df4e995
+  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
+  FirebaseCrashlytics: 6b0613b548fe096221b5ba6d2f7a9732b451233b
+  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
+  GoogleAppMeasurement: 7e48a3249792ac35d6f18f107f63f199a7e9d0ce
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   GRDB.swift: 3eb7447131d897afb420d6877a45fd8bfca313c1
   Instabug: 4f26295103a330ec0236918359eef7ccaa74e2fa
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
-  OktaAnalytics: 8e720181e3fd148b2af29a6c3292cb240719a247
-  OktaLogger: 26fd2a28ab9feb06291cc13a7207d7c8635ed0d6
+  OktaAnalytics: 4a9b265fc7f7634aa564505446cb3dad8fa72b8c
+  OktaLogger: 95ed246189fabbdb4efb151bd8757ca1675fdad2
   OktaSQLiteStorage: 4761bb59ed2d6fc2ba6184a4fdd79f2fbeadc50c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   SQLCipher: f2e96b3822e3006b379181a0e4fd145f6de29b56
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
 
-PODFILE CHECKSUM: 93a0073cc8b074d7ea487afb97158a9ccbc6d93b
+PODFILE CHECKSUM: 942255937ba8edbf224f3e5292da86a83ec0c8c4
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,87 +10,99 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - Firebase/AnalyticsWithoutAdIdSupport (10.0.0):
+  - Firebase/AnalyticsWithoutAdIdSupport (11.3.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics/WithoutAdIdSupport (~> 10.0.0)
-  - Firebase/CoreOnly (10.0.0):
-    - FirebaseCore (= 10.0.0)
-  - Firebase/Crashlytics (10.0.0):
+    - FirebaseAnalytics/WithoutAdIdSupport (~> 11.3.0)
+  - Firebase/CoreOnly (11.3.0):
+    - FirebaseCore (= 11.3.0)
+  - Firebase/Crashlytics (11.3.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.0.0)
-  - FirebaseAnalytics/WithoutAdIdSupport (10.0.0):
-    - FirebaseCore (~> 10.0)
-    - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.0.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/MethodSwizzler (~> 7.8)
-    - GoogleUtilities/Network (~> 7.8)
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.0.0):
-    - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.29.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.0.0):
-    - FirebaseCore (~> 10.0)
-    - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.2)
-    - GoogleUtilities/Environment (~> 7.8)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-    - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (10.29.0):
-    - FirebaseCore (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - PromisesObjC (~> 2.1)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.0.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/MethodSwizzler (~> 7.8)
-    - GoogleUtilities/Network (~> 7.8)
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
+    - FirebaseCrashlytics (~> 11.3.0)
+  - FirebaseAnalytics/WithoutAdIdSupport (11.3.0):
+    - FirebaseCore (~> 11.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.3.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
+    - GoogleUtilities/MethodSwizzler (~> 8.0)
+    - GoogleUtilities/Network (~> 8.0)
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+    - nanopb (~> 3.30910.0)
+  - FirebaseCore (11.3.0):
+    - FirebaseCoreInternal (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Logger (~> 8.0)
+  - FirebaseCoreExtension (11.3.0):
+    - FirebaseCore (~> 11.0)
+  - FirebaseCoreInternal (11.3.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+  - FirebaseCrashlytics (11.3.0):
+    - FirebaseCore (~> 11.0)
+    - FirebaseInstallations (~> 11.0)
+    - FirebaseRemoteConfigInterop (~> 11.0)
+    - FirebaseSessions (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseInstallations (11.3.0):
+    - FirebaseCore (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseRemoteConfigInterop (11.3.0)
+  - FirebaseSessions (11.3.0):
+    - FirebaseCore (~> 11.0)
+    - FirebaseCoreExtension (~> 11.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - nanopb (~> 3.30910.0)
+    - PromisesSwift (~> 2.1)
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.3.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
+    - GoogleUtilities/MethodSwizzler (~> 8.0)
+    - GoogleUtilities/Network (~> 8.0)
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+    - nanopb (~> 3.30910.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.3):
+  - GoogleUtilities/Environment (8.0.2):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (7.13.3):
+  - GoogleUtilities/MethodSwizzler (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.3):
+  - GoogleUtilities/Network (8.0.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.3)":
+  - "GoogleUtilities/NSData+zlib (8.0.2)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/Reachability (7.13.3):
+  - GoogleUtilities/Privacy (8.0.2)
+  - GoogleUtilities/Reachability (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GRDB.swift/SQLCipher (6.20.2):
     - SQLCipher (>= 3.4.2)
   - Instabug (13.3.0)
-  - nanopb (2.30909.1):
-    - nanopb/decode (= 2.30909.1)
-    - nanopb/encode (= 2.30909.1)
-  - nanopb/decode (2.30909.1)
-  - nanopb/encode (2.30909.1)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - OktaAnalytics (2.1):
     - AppCenter (~> 5)
     - Firebase/AnalyticsWithoutAdIdSupport
@@ -107,7 +119,7 @@ PODS:
     - CocoaLumberjack/Swift (~> 3)
     - OktaLogger/Core
   - OktaLogger/FirebaseCrashlytics (1.3.20):
-    - Firebase/Crashlytics (~> 10)
+    - Firebase/Crashlytics (~> 11)
     - OktaLogger/Core
   - OktaLogger/InstabugLogger (1.3.20):
     - Instabug (~> 13)
@@ -116,6 +128,8 @@ PODS:
     - GRDB.swift/SQLCipher (= 6.20.2)
     - SQLCipher (= 4.5.5)
   - PromisesObjC (2.4.0)
+  - PromisesSwift (2.4.0):
+    - PromisesObjC (= 2.4.0)
   - SQLCipher (4.5.5):
     - SQLCipher/standard (= 4.5.5)
   - SQLCipher/common (4.5.5)
@@ -127,7 +141,7 @@ DEPENDENCIES:
   - AppCenter (~> 5.0.0)
   - CocoaLumberjack/Swift (~> 3.6.0)
   - Firebase/AnalyticsWithoutAdIdSupport
-  - Firebase/Crashlytics (~> 10.0.0)
+  - Firebase/Crashlytics (~> 11.3.0)
   - GRDB.swift/SQLCipher (= 6.20.2)
   - Instabug (= 13.3.0)
   - OktaAnalytics (from `.`)
@@ -144,9 +158,12 @@ SPEC REPOS:
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
+    - FirebaseCoreExtension
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
+    - FirebaseRemoteConfigInterop
+    - FirebaseSessions
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
@@ -154,6 +171,7 @@ SPEC REPOS:
     - Instabug
     - nanopb
     - PromisesObjC
+    - PromisesSwift
     - SQLCipher
     - SwiftLint
 
@@ -168,25 +186,29 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppCenter: 994875ea7941b9e168babb98299f900a94bcef13
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  Firebase: 1b810f3d0c0532e27a48f1961f8c0400a668a2cf
-  FirebaseAnalytics: 9921a52739f4ab66099da31b6e0243db78a3ac0a
-  FirebaseCore: 97f48a3a567a72b8d4daa0f03c3aadb78df4e995
-  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
-  FirebaseCrashlytics: 6b0613b548fe096221b5ba6d2f7a9732b451233b
-  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
-  GoogleAppMeasurement: 7e48a3249792ac35d6f18f107f63f199a7e9d0ce
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  Firebase: 5c575140761e22324806f401e38c483d58db2dec
+  FirebaseAnalytics: ce1593872635a5ebd715d0d3937fab195991ecc9
+  FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
+  FirebaseCoreExtension: 30bb063476ef66cd46925243d64ad8b2c8ac3264
+  FirebaseCoreInternal: ac26d09a70c730e497936430af4e60fb0c68ec4e
+  FirebaseCrashlytics: ba7b6a55dc10393f6583d87d8600d0d3ab2671d8
+  FirebaseInstallations: 58cf94dabf1e2bb2fa87725a9be5c2249171cda0
+  FirebaseRemoteConfigInterop: c3a5c31b3c22079f41ba1dc645df889d9ce38cb9
+  FirebaseSessions: 655ff17f3cc1a635cbdc2d69b953878001f9e25b
+  GoogleAppMeasurement: c8bac5f6ad85d3a0bdf2b9aee7fd484d6615d486
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GRDB.swift: 3eb7447131d897afb420d6877a45fd8bfca313c1
   Instabug: 4f26295103a330ec0236918359eef7ccaa74e2fa
-  nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OktaAnalytics: 4a9b265fc7f7634aa564505446cb3dad8fa72b8c
-  OktaLogger: 95ed246189fabbdb4efb151bd8757ca1675fdad2
+  OktaLogger: 5e1f38582dd2087b4f321fe948a8613e39e9e580
   OktaSQLiteStorage: 4761bb59ed2d6fc2ba6184a4fdd79f2fbeadc50c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SQLCipher: f2e96b3822e3006b379181a0e4fd145f6de29b56
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
 
-PODFILE CHECKSUM: 942255937ba8edbf224f3e5292da86a83ec0c8c4
+PODFILE CHECKSUM: 5667fd7a1d4990d8e23a648ebfa747f6f3d8acbe
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -202,7 +202,7 @@ SPEC CHECKSUMS:
   Instabug: 4f26295103a330ec0236918359eef7ccaa74e2fa
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OktaAnalytics: 4a9b265fc7f7634aa564505446cb3dad8fa72b8c
-  OktaLogger: 5e1f38582dd2087b4f321fe948a8613e39e9e580
+  OktaLogger: 25cb42a2ff6defbb234f1dd7c1f066011678c762
   OktaSQLiteStorage: 4761bb59ed2d6fc2ba6184a4fdd79f2fbeadc50c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851

--- a/Tests/OktaAnalyticsTests/OktaAnalyticsTests.swift
+++ b/Tests/OktaAnalyticsTests/OktaAnalyticsTests.swift
@@ -79,6 +79,7 @@ class OktaAnalyticsTests: XCTestCase {
             OktaAnalytics.startScenario(ScenarioEvent(scenarioID: UUID().uuidString, name: "Test \(index)", displayName: " \(index)")) {
                 scenarioID = $0 ?? ""
             }
+            sleep(1)
             OktaAnalytics.updateScenario(scenarioID, [Property(key: "Test1", value: "1")])
             OktaAnalytics.updateScenario(scenarioID, [Property(key: "Test2", value: "2")])
             OktaAnalytics.updateScenario(scenarioID, [Property(key: "Test3", value: "3")])


### PR DESCRIPTION
- Updated Firebase dependency in `OktaLogger.podspec` compatible with Firebase version 11 and changed minimal deployment target for iOS (required for Firebase 11)
- Fixed flaky test for `OktaAnalytics`