### PR TITLE
OKTA-820665 - Remove unused targets in SPM Package except OktaFileLogger

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,33 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      "state" : {
-        "revision" : "d302de612e3d57c6f4afaf087da18fba8eac72a7",
-        "version" : "0.20220203.1"
-      }
-    },
-    {
-      "identity" : "appcenter-sdk-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
-      "state" : {
-        "revision" : "b2dc99cfedead0bad4e6573d86c5228c89cff332",
-        "version" : "4.4.3"
-      }
-    },
-    {
-      "identity" : "boringssl-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
-      "state" : {
-        "revision" : "79db6516894a932d0ddaff3b05b9da1e4f6c4069",
-        "version" : "0.9.0"
-      }
-    },
-    {
       "identity" : "cocoalumberjack",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
@@ -37,120 +10,12 @@
       }
     },
     {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
-      "state" : {
-        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
-        "version" : "9.6.0"
-      }
-    },
-    {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
-        "version" : "9.6.0"
-      }
-    },
-    {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
-        "version" : "9.2.1"
-      }
-    },
-    {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
-      "state" : {
-        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
-        "version" : "7.11.0"
-      }
-    },
-    {
-      "identity" : "grpc-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
-      "state" : {
-        "revision" : "abd2d5a4347efa0454606a788678a5d8ec223738",
-        "version" : "1.44.0-grpc"
-      }
-    },
-    {
-      "identity" : "gtm-session-fetcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
-      "state" : {
-        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
-        "version" : "2.3.0"
-      }
-    },
-    {
-      "identity" : "instabug-sp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Instabug/Instabug-SP",
-      "state" : {
-        "revision" : "7d89a79d7d82a1295699f3ca87f95d59b8e91390",
-        "version" : "11.7.0"
-      }
-    },
-    {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
-        "version" : "1.22.2"
-      }
-    },
-    {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
-        "version" : "2.30909.0"
-      }
-    },
-    {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/PLCrashReporter.git",
-      "state" : {
-        "revision" : "81cdec2b3827feb03286cb297f4c501a8eb98df1",
-        "version" : "1.10.2"
-      }
-    },
-    {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "46c1e6b5ac09d8f82c991061c659f67e573d425d",
-        "version" : "2.1.0"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
         "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
         "version" : "1.5.4"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "e1499bc69b9040b29184f7f2996f7bab467c1639",
-        "version" : "1.19.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,30 +22,18 @@ let package = Package(
         .library(
             name: "OktaFileLogger",
             targets: ["FileLogger"]),
-        .library(
-            name: "OktaFirebaseCrashlyticsLogger",
-            targets: ["FirebaseCrashlyticsLogger"]),
-        .library(
-            name: "OktaInstabugLogger",
-            targets: ["InstabugLogger"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Instabug/Instabug-SP", .upToNextMajor(from: "11.2.0")),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "9.6.0")),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.6.0")),
-        .package(url: "https://github.com/microsoft/appcenter-sdk-apple.git", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [
         .target(
             name: "OktaLogger",
             dependencies: [
                 .target(name: "FileLogger"),
-                .target(name: "FirebaseCrashlyticsLogger"),
-                .target(name: "InstabugLogger"),
                 .target(name: "LoggerCore"),
             ],
-            exclude: ["AppCenterLogger",
-                      "FileLoggers",
+            exclude: ["FileLoggers",
                       "FirebaseCrashlyticsLogger",
                       "InstabugLogger",
                       "LoggerCore",
@@ -56,18 +44,6 @@ let package = Package(
                 .target(name: "LoggerCore")
                ],
                 path: "Sources/OktaLogger/FileLoggers"),
-        .target(name: "FirebaseCrashlyticsLogger",
-                dependencies: [
-                    .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
-                    .target(name: "LoggerCore")
-                ],
-                path: "Sources/OktaLogger/FirebaseCrashlyticsLogger"),
-        .target(name: "InstabugLogger",
-               dependencies: [
-                    .product(name: "Instabug", package: "Instabug-SP"),
-                    .target(name: "LoggerCore")
-               ],
-                path: "Sources/OktaLogger/InstabugLogger"),
         .target(
             name: "LoggerCore",
             dependencies: [],


### PR DESCRIPTION
Push SDK only uses OktaFileLogger as dependency and SPM currently resolves ALL dependencies in the OktaLogger repo instead of just the imported project (OktaFileLogger).
Since there are no other projects using Firebase and Instabug via SPM, we can remove and leave only OktaFileLogger so we can unblock PushSDK customers using conflicting Firebase versions.